### PR TITLE
docs: expand module documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,30 @@ Generate content summaries in Drupal using providers from the AI module.
 3. Configure at `/admin/config/content/ai-content-summary`.
 
 ## Usage
-- On enabled content types, click **Generate AI Summary** to fill the summary field.
+Once configured, the module adds a **Generate AI Summary** button to the edit forms of
+allowed content types. Clicking the button sends the saved content to your default AI
+provider and writes the returned summary into the summary field. The request uses the
+configured prompt and length settings. Because the service reads the saved node data,
+you should save the node before generating a new summary if you have unsaved changes.
 
 ## Permissions
 - **Administer AI Content Summary**
 - **Generate AI summaries**
 
 ## Configuration
-Choose the prompt, min/max length, view mode, and allowed content types.
+Configuration lives at `/admin/config/content/ai-content-summary`.
+
+Here you can:
+
+- Enter the prompt that will be sent to the AI provider.
+- Choose minimum and maximum summary lengths.
+- Specify a view mode used to extract the text that will be summarized. Creating a
+  dedicated view mode (e.g. `ai_summary_source`) lets you control exactly which fields
+  are passed to the AI service.
+- Select which content types should expose the summary generation button.
+
+The module relies on the AI core module for provider configuration, so ensure that a
+chat‑capable provider is enabled and set as the default for chat operations.
 
 ## License
 Licensed under the MIT License. See the `LICENSE` file for details.

--- a/js/summary-generator.js
+++ b/js/summary-generator.js
@@ -6,8 +6,12 @@
 
   /**
    * Attaches behavior for generating summaries through AJAX.
+   *
+   * @param {HTMLElement} context
+   *   The current DOM context.
+   * @param {object} settings
+   *   Drupal settings for the page.
    */
-
   Drupal.behaviors.aiContentSummary = {
     attach: function (context, settings) {
       $('.ai-summary-generate-button', context)


### PR DESCRIPTION
## Summary
- expand README with detailed usage and configuration guidance
- document parameters for the AJAX behavior in summary-generator.js

## Testing
- `node --check js/summary-generator.js`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_b_68c76b6c0214832fbdcd251cb46b6cee